### PR TITLE
iOS SDK release 1.2.5

### DIFF
--- a/_docs/sdk/ios.md
+++ b/_docs/sdk/ios.md
@@ -49,7 +49,7 @@ import Smartlook
 
 ### Manual installation
 
-1. Download [Smartlook iOS SDK v1.2.4](https://sdk.smartlook.com/ios/smartlook-ios-sdk-1.2.4.53.zip) directly.
+1. Download [Smartlook iOS SDK v1.2.5](https://sdk.smartlook.com/ios/smartlook-ios-sdk-1.2.5.59.zip) directly.
 2. Unzip the file and add Smartlook.framework to your Xcode project.
 3. Import Smartlook SDK in your app's App Delegate class:
 ```swift


### PR DESCRIPTION
Just the new release link.

iOS SDK is now build using Xcode 10 to avoid `___isPlatformVersionAtLeast` undefined symbol issue. 

https://github.com/smartlook/smartlook-ios-sdk/blob/master/README.md#125---2019-11-11