### PR TITLE
Fix Cordova and Ionic docs by adding iOS support

### DIFF
--- a/_docs/sdk/cordova.md
+++ b/_docs/sdk/cordova.md
@@ -1,6 +1,6 @@
 ---
-title: "Ionic Android"
-subtitle: "SDK for screen recording and analytics for Ionic Android applications."
+title: "Cordova"
+subtitle: "SDK for screen recording and analytics for Cordova applications."
 description: "This SDK offers several options to developers and/or companies."
 ---
 
@@ -15,34 +15,23 @@ description: "This SDK offers several options to developers and/or companies."
 
 For more information on how to report issues please check our [Smartlook SDK Support section](https://smartlook.github.io/docs/sdk/support/#how-to-submit-an-issue).
 
-[Smartlook Android SDK changelog](https://github.com/smartlook/smartlook-android-sdk) reports all notable improvements, changes and fixes in SDK releases.
+Smartlook [Android SDK changelog](https://github.com/smartlook/smartlook-android-sdk) and [iOS SDK changelog](https://github.com/smartlook/smartlook-ios-sdk) report all notable improvements, changes and fixes in SDK releases.
 
 ## Supported versions
 
-Currently, we support API 18+ for recording.
+Currently, we support Android API 18+ and iOS 10+ for recording.
 
 ## Installation
 
-Add Ionic plugin to your project:
+Add cordova plugin to your project:
 
 ```
-npm install @ionic-native/smartlook --save
-ionic cordova plugin add https://github.com/smartlook/cordova-smartlook.git
+cordova plugin add https://github.com/smartlook/cordova-smartlook.git
 ```
 
 ## API Reference
 
 Applications can interact with the SDK using public SDK functions.
-
-### SDK injection
-
-You can inject Smartlook SDK like this:
-
-```typescript
-import { Smartlook } from '@ionic-native/smartlook/ngx';
-
-constructor(private smartlook: Smartlook) { }
-```
 
 ### Setup
 
@@ -51,89 +40,110 @@ You need to provide your **Smartlook SDK Key** which can be acquired in the [Sma
 
 If you want to setup SDK and start recording, use:
 
-```typescript
-smartlook.setupAndStartRecording(new SmartlookSetupConfig(smartlookAPIKey: string))
+```javascript
+cordova.plugins.SmartlookPlugin.setupAndStartRecording({smartlookAPIKey: "key"});
 ```
 
 In case you want to configure recorded video framerate (allowed values between 2 and 10), use:
 
-```typescript
-smartlook.setupAndStartRecording(new SmartlookSetupConfig(smartlookAPIKey: string, fps: number))
+```javascript
+cordova.plugins.SmartlookPlugin.setupAndStartRecording({smartlookAPIKey: "key", fps: 2});
 ```
 
 If you want to start recording later use:
 
-```typescript
-smartlook.setup(new SmartlookSetupConfig(smartlookAPIKey: string, fps?: number));
+```javascript
+cordova.plugins.SmartlookPlugin.setup({smartlookAPIKey: "key"});
 ```
 
-Best place to call one of these functions is on Application initialization.
+Best place to call one of these functions is in on `deviceready`.
+
+```javascript
+Dom7(document).on('deviceready', function deviceIsReady() {
+  // here
+});
+```
 
 ### Start and stop recording
 
 If you have SDK set-up you can start or stop recording by calling:
 
-```typescript
-smartlook.startRecording();
-smartlook.stopRecording()
+```javascript
+cordova.plugins.SmartlookPlugin.startRecording();
+cordova.plugins.SmartlookPlugin.stopRecording()
 ```
 
 ### Check if SDK is recording
 
 If you are using `startRecording()` and `stopRecording()` methods it might be handy to know if SDK is currently recording or not.
-Simply call `isRecording` and check the promise for result:
+Simply call `isRecording` and check callback for result:
 
-```typescript
-this.smartlook.isRecording().then((isRecording) => {
-  alert(isRecording)
-});
+```javascript
+cordova.plugins.SmartlookPlugin.isRecording(
+    function(isRecording){
+        //check here 
+    }
+)
 ```
 
 ### Sensitive mode
 
 In case you don't want SDK to record user video, but still, want it to send analytic events you can use sensitive mode.
 
-```typescript
-smartlook.startFullscreenSensitiveMode()
+```javascript
+cordova.plugins.SmartlookPlugin.startFullscreenSensitiveMode()
 ```
 
 Instead of application recording, the video will be black when the sensitive mode is active.
 
 Sensitive mode can be stopped like this:
 
-```typescript
-smartlook.stopFullscreenSensitiveMode()
+```javascript
+cordova.plugins.SmartlookPlugin.stopFullscreenSensitiveMode()
 ```
 
 If you want to check if the sensitive mode is active, use:
 
-```typescript
-smartlook.isFullscreenSensitiveModeActive().then((isActive) => {
-  alert(isActive)
-});
+```javascript
+cordova.plugins.SmartlookPlugin.isFullscreenSensitiveModeActive(
+    function(isFullscreenSensitiveModeActive){
+        //check here
+    }
+)
 ```
+
+### Sensitive Elements
+
+If you want to hide a specific element, you can add the 'smartlook-hide' class:
+
+```
+class="smartlook-hide"
+```
+
+Note that Smartlook **automatically hides text input elements**.
 
 ### Add user id & properties
 
 You can specify your app’s user identifier by calling:
 
-```typescript
-smartlook.setUserIdentifier(new SmartlookUserIdentifier(identifier: string));
+```javascript
+cordova.plugins.SmartlookPlugin.setUserIdentifier({identifier: "CordovaUser"})
 ``` 
 
 You can then look up those identifiers in the Dashboard to find specific user’s recordings.
 
 Additional user information, such as name, email and other custom properties can be set by calling:
 
-```typescript
-smartlook.setUserIdentifier(new SmartlookUserIdentifier(identifier: string, sessionProperties: {}));
+```javascript
+cordova.plugins.SmartlookPlugin.setUserIdentifier(
+    {identifier: "CordovaUser", sessionProperties: {name: "Cordova", surname: "User"}})
 ``` 
 
 You’ll see those properties in the Dashboard in Visitor details.
 
 ### Analytics
 
-Unlike in native Android applications, Smartlook Ionic SDK cannot automaticaly detect:
+Unlike in native applications, Smartlook Cordova SDK cannot automaticaly detect:
 * Focus events
 * Clicked Views
 
@@ -148,14 +158,15 @@ Focus, click and more custom events can be tracked by using custom events.
 
 You can track custom event by calling:
 
-```typescript
-smartlook.trackCustomEvent(new SmartlookCustomEvent(name: string));
+```javascript
+cordova.plugins.SmartlookPlugin.trackCustomEvent({name: "button_click"})
 ``` 
 
 If you need to send some additional data with custom event use:
 
-```typescript
-smartlook.trackCustomEvent(new SmartlookCustomEvent(name: string, eventProperties: {}));
+```javascript
+cordova.plugins.SmartlookPlugin.trackCustomEvent(
+    {name: "button_click", eventProperties: {id: "button_id", text: "click me!"}})
 ``` 
 
 Additional data can be used in **funnels** or any additional **filtering**. 
@@ -165,26 +176,27 @@ Additional data can be used in **funnels** or any additional **filtering**.
 In case you want to measure the duration of any time-sensitive or long-running actions in the app.
 You can call:
 
-```typescript
-smartlook.startTimedCustomEvent(new SmartlookCustomEvent(name: string));
+```javascript
+cordova.plugins.SmartlookPlugin.startTimedCustomEvent({name: "download_finish"})
 ```
 
 This will not send out any event, but once `track(...)` with corresponding event name gets called it will have extra **duration** property. 
 
 You can set some aditional data by calling:
 
-```typescript
-smartlook.startTimedCustomEvent(new SmartlookCustomEvent(name: string, eventProperties: {}));
+```javascript
+cordova.plugins.SmartlookPlugin.startTimedCustomEvent(
+    {name: "download_finish", eventProperties: {timestamp: "2019-01-10T11:00:00+00:00"}})
 ```
 
 Properties set in `startTimedCustomEvent` will be merged with properties set in `trackCustomEvent`. Properties from `trackCustomEvent` have higher priority and will rewrite conflicting properties from `startTimedCustomEvent`.
 
 Typical use of timed event might look like this:
 
-```typescript
-smartlook.startTimedCustomEvent(new SmartlookCustomEvent("download_finish"));
+```javascript
+cordova.plugins.SmartlookPlugin.startTimedCustomEvent({name: "download_finish"})
 sleep(1000) //long running operation
-smartlook.trackCustomEvent(new SmartlookCustomEvent("download_finish"))
+cordova.plugins.SmartlookPlugin.trackCustomEvent({name: "download_finish"})
 ```
 In this case `download_finish` will have duration property set to circa `1000ms`.
 
@@ -192,16 +204,16 @@ In this case `download_finish` will have duration property set to circa `1000ms`
 
 Event super properties can be set by calling:
 
-```typescript
-smartlook.setGlobalEventProperties(new SmartlookGlobalEventProperties(
-  globalEventProperties: {}, immutable: boolean));
+```javascript
+cordova.plugins.SmartlookPlugin.setGlobalEventProperties(
+    {globalEventProperties: {global: "Property", second: "one"}, immutable: false})
 ```
 
 or
 
-```typescript
-smartlook.setGlobalEventProperty(new SmartlookGlobalEventProperty(
-    key: string, value: string, immutable: boolean))
+```javascript
+cordova.plugins.SmartlookPlugin.setGlobalEventProperty(
+    {key: "unique", value: "simple property", immutable: false})
 ```
 
 Such properties are added to any event sent from the client in the future. Properties in global scope have higher priority so in merging process those from global scope will **override** custom properties with the same key.
@@ -211,14 +223,14 @@ Properties set to be `immutable` have the highest priority and once set they can
 ### Remove global event property
 If you want to remove some global property with a given key call:
 
-```typescript
-smartlook.removeGlobalEventProperty(SmartlookGlobalEventPropertyKey(key: string))
+```javascript
+cordova.plugins.SmartlookPlugin.removeGlobalEventProperty({key: "property_to_remove"})
 ```
 
 Or you can remove all global event properties:
 
-```typescript
-smartlook.removeAllGlobalEventProperties()
+```javascript
+cordova.plugins.SmartlookPlugin.removeAllGlobalEventProperties()
 ```
 
 Note that global event properties are stored until they are not removed or the app is uninstalled.

--- a/_docs/sdk/ionic.md
+++ b/_docs/sdk/ionic.md
@@ -1,6 +1,6 @@
 ---
-title: "Cordova Android"
-subtitle: "SDK for screen recording and analytics for Cordova Android applications."
+title: "Ionic"
+subtitle: "SDK for screen recording and analytics for Ionic applications."
 description: "This SDK offers several options to developers and/or companies."
 ---
 
@@ -15,23 +15,34 @@ description: "This SDK offers several options to developers and/or companies."
 
 For more information on how to report issues please check our [Smartlook SDK Support section](https://smartlook.github.io/docs/sdk/support/#how-to-submit-an-issue).
 
-[Smartlook Android SDK changelog](https://github.com/smartlook/smartlook-android-sdk) reports all notable improvements, changes and fixes in SDK releases.
+Smartlook [Android SDK changelog](https://github.com/smartlook/smartlook-android-sdk) and [iOS SDK changelog](https://github.com/smartlook/smartlook-ios-sdk) report all notable improvements, changes and fixes in SDK releases.
 
 ## Supported versions
 
-Currently, we support API 18+ for recording.
+Currently, we support Android API 18+ and iOS 10+ for recording.
 
 ## Installation
 
-Add cordova plugin to your project:
+Add Ionic plugin to your project:
 
 ```
-cordova plugin add https://github.com/smartlook/cordova-smartlook.git
+npm install @ionic-native/smartlook --save
+ionic cordova plugin add https://github.com/smartlook/cordova-smartlook.git
 ```
 
 ## API Reference
 
 Applications can interact with the SDK using public SDK functions.
+
+### SDK injection
+
+You can inject Smartlook SDK like this:
+
+```typescript
+import { Smartlook } from '@ionic-native/smartlook/ngx';
+
+constructor(private smartlook: Smartlook) { }
+```
 
 ### Setup
 
@@ -40,110 +51,89 @@ You need to provide your **Smartlook SDK Key** which can be acquired in the [Sma
 
 If you want to setup SDK and start recording, use:
 
-```javascript
-cordova.plugins.SmartlookPlugin.setupAndStartRecording({smartlookAPIKey: "key"});
+```typescript
+smartlook.setupAndStartRecording(new SmartlookSetupConfig(smartlookAPIKey: string))
 ```
 
 In case you want to configure recorded video framerate (allowed values between 2 and 10), use:
 
-```javascript
-cordova.plugins.SmartlookPlugin.setupAndStartRecording({smartlookAPIKey: "key", fps: 2});
+```typescript
+smartlook.setupAndStartRecording(new SmartlookSetupConfig(smartlookAPIKey: string, fps: number))
 ```
 
 If you want to start recording later use:
 
-```javascript
-cordova.plugins.SmartlookPlugin.setup({smartlookAPIKey: "key"});
+```typescript
+smartlook.setup(new SmartlookSetupConfig(smartlookAPIKey: string, fps?: number));
 ```
 
-Best place to call one of these functions is in on `deviceready`.
-
-```javascript
-Dom7(document).on('deviceready', function deviceIsReady() {
-  // here
-});
-```
+Best place to call one of these functions is on Application initialization.
 
 ### Start and stop recording
 
 If you have SDK set-up you can start or stop recording by calling:
 
-```javascript
-cordova.plugins.SmartlookPlugin.startRecording();
-cordova.plugins.SmartlookPlugin.stopRecording()
+```typescript
+smartlook.startRecording();
+smartlook.stopRecording()
 ```
 
 ### Check if SDK is recording
 
 If you are using `startRecording()` and `stopRecording()` methods it might be handy to know if SDK is currently recording or not.
-Simply call `isRecording` and check callback for result:
+Simply call `isRecording` and check the promise for result:
 
-```javascript
-cordova.plugins.SmartlookPlugin.isRecording(
-    function(isRecording){
-        //check here 
-    }
-)
+```typescript
+this.smartlook.isRecording().then((isRecording) => {
+  alert(isRecording)
+});
 ```
 
 ### Sensitive mode
 
 In case you don't want SDK to record user video, but still, want it to send analytic events you can use sensitive mode.
 
-```javascript
-cordova.plugins.SmartlookPlugin.startFullscreenSensitiveMode()
+```typescript
+smartlook.startFullscreenSensitiveMode()
 ```
 
 Instead of application recording, the video will be black when the sensitive mode is active.
 
 Sensitive mode can be stopped like this:
 
-```javascript
-cordova.plugins.SmartlookPlugin.stopFullscreenSensitiveMode()
+```typescript
+smartlook.stopFullscreenSensitiveMode()
 ```
 
 If you want to check if the sensitive mode is active, use:
 
-```javascript
-cordova.plugins.SmartlookPlugin.isFullscreenSensitiveModeActive(
-    function(isFullscreenSensitiveModeActive){
-        //check here
-    }
-)
+```typescript
+smartlook.isFullscreenSensitiveModeActive().then((isActive) => {
+  alert(isActive)
+});
 ```
-
-### Sensitive Elements
-
-If you want to hide a specific element, you can add the 'smartlook-hide' class:
-
-```
-class="smartlook-hide"
-```
-
-Note that Smartlook **automatically hides text input elements**.
 
 ### Add user id & properties
 
 You can specify your app’s user identifier by calling:
 
-```javascript
-cordova.plugins.SmartlookPlugin.setUserIdentifier({identifier: "CordovaUser"})
+```typescript
+smartlook.setUserIdentifier(new SmartlookUserIdentifier(identifier: string));
 ``` 
 
 You can then look up those identifiers in the Dashboard to find specific user’s recordings.
 
 Additional user information, such as name, email and other custom properties can be set by calling:
 
-```javascript
-cordova.plugins.SmartlookPlugin.setUserIdentifier(
-    {identifier: "CordovaUser", sessionProperties: {name: "Cordova", surname: "User"}})
+```typescript
+smartlook.setUserIdentifier(new SmartlookUserIdentifier(identifier: string, sessionProperties: {}));
 ``` 
 
 You’ll see those properties in the Dashboard in Visitor details.
 
 ### Analytics
 
-Unlike in native Android applications, Smartlook Cordova SDK cannot automaticaly detect:
+Unlike in native applications, Smartlook Ionic SDK cannot automaticaly detect:
 * Focus events
 * Clicked Views
 
@@ -158,15 +148,14 @@ Focus, click and more custom events can be tracked by using custom events.
 
 You can track custom event by calling:
 
-```javascript
-cordova.plugins.SmartlookPlugin.trackCustomEvent({name: "button_click"})
+```typescript
+smartlook.trackCustomEvent(new SmartlookCustomEvent(name: string));
 ``` 
 
 If you need to send some additional data with custom event use:
 
-```javascript
-cordova.plugins.SmartlookPlugin.trackCustomEvent(
-    {name: "button_click", eventProperties: {id: "button_id", text: "click me!"}})
+```typescript
+smartlook.trackCustomEvent(new SmartlookCustomEvent(name: string, eventProperties: {}));
 ``` 
 
 Additional data can be used in **funnels** or any additional **filtering**. 
@@ -176,27 +165,26 @@ Additional data can be used in **funnels** or any additional **filtering**.
 In case you want to measure the duration of any time-sensitive or long-running actions in the app.
 You can call:
 
-```javascript
-cordova.plugins.SmartlookPlugin.startTimedCustomEvent({name: "download_finish"})
+```typescript
+smartlook.startTimedCustomEvent(new SmartlookCustomEvent(name: string));
 ```
 
 This will not send out any event, but once `track(...)` with corresponding event name gets called it will have extra **duration** property. 
 
 You can set some aditional data by calling:
 
-```javascript
-cordova.plugins.SmartlookPlugin.startTimedCustomEvent(
-    {name: "download_finish", eventProperties: {timestamp: "2019-01-10T11:00:00+00:00"}})
+```typescript
+smartlook.startTimedCustomEvent(new SmartlookCustomEvent(name: string, eventProperties: {}));
 ```
 
 Properties set in `startTimedCustomEvent` will be merged with properties set in `trackCustomEvent`. Properties from `trackCustomEvent` have higher priority and will rewrite conflicting properties from `startTimedCustomEvent`.
 
 Typical use of timed event might look like this:
 
-```javascript
-cordova.plugins.SmartlookPlugin.startTimedCustomEvent({name: "download_finish"})
+```typescript
+smartlook.startTimedCustomEvent(new SmartlookCustomEvent("download_finish"));
 sleep(1000) //long running operation
-cordova.plugins.SmartlookPlugin.trackCustomEvent({name: "download_finish"})
+smartlook.trackCustomEvent(new SmartlookCustomEvent("download_finish"))
 ```
 In this case `download_finish` will have duration property set to circa `1000ms`.
 
@@ -204,16 +192,16 @@ In this case `download_finish` will have duration property set to circa `1000ms`
 
 Event super properties can be set by calling:
 
-```javascript
-cordova.plugins.SmartlookPlugin.setGlobalEventProperties(
-    {globalEventProperties: {global: "Property", second: "one"}, immutable: false})
+```typescript
+smartlook.setGlobalEventProperties(new SmartlookGlobalEventProperties(
+  globalEventProperties: {}, immutable: boolean));
 ```
 
 or
 
-```javascript
-cordova.plugins.SmartlookPlugin.setGlobalEventProperty(
-    {key: "unique", value: "simple property", immutable: false})
+```typescript
+smartlook.setGlobalEventProperty(new SmartlookGlobalEventProperty(
+    key: string, value: string, immutable: boolean))
 ```
 
 Such properties are added to any event sent from the client in the future. Properties in global scope have higher priority so in merging process those from global scope will **override** custom properties with the same key.
@@ -223,14 +211,14 @@ Properties set to be `immutable` have the highest priority and once set they can
 ### Remove global event property
 If you want to remove some global property with a given key call:
 
-```javascript
-cordova.plugins.SmartlookPlugin.removeGlobalEventProperty({key: "property_to_remove"})
+```typescript
+smartlook.removeGlobalEventProperty(SmartlookGlobalEventPropertyKey(key: string))
 ```
 
 Or you can remove all global event properties:
 
-```javascript
-cordova.plugins.SmartlookPlugin.removeAllGlobalEventProperties()
+```typescript
+smartlook.removeAllGlobalEventProperties()
 ```
 
 Note that global event properties are stored until they are not removed or the app is uninstalled.


### PR DESCRIPTION
- Rename documents by removing `-android` from the name.
- Change formulations to reflect support for both (Android and iOS) platforms.