### PR TITLE
Partially fix the English in the GDPR help

### DIFF
--- a/_docs/web/gdpr.md
+++ b/_docs/web/gdpr.md
@@ -1,21 +1,21 @@
 ---
 title: "GDPR"
-subtitle: "Record user information of EU visitors."
+subtitle: "Record user information about EU visitors."
 description: "Depending on content you record you need your user’s consent."
 ---
 
-Make sure you enabled required project settings before using this API.
+Make sure you enabled the corresponding project settings before using this API.
 {: .callout .callout-warning }
 
 ## Verify user consent
 
-Read more about [GDPR](https://www.smartlook.com/help/gdpr/){:target="_blank"} in our HELP section. Once user gave you his consent use this API. The code below needs to be adjusted based on what answer you received.
+Read more about [GDPR](https://www.smartlook.com/help/gdpr/){:target="_blank"} in our HELP section. Once the user gave consent, you can use this API. The code below needs to be adjusted based on the user's answer.
 
-At Smartlook we use pop up window to ask for user consent. You should implement similar solution on your site.
+At Smartlook we use a pop-up window to ask for user consent. You should implement a similar solution on your site.
 
 ![user consent](/assets/img/docs/web/gdpr/consent.png)
 
-Verify if a visitor gave his consent or not by using this code.
+Verify if a visitor gave their consent or not:
 
 ```js
 <script>
@@ -35,7 +35,7 @@ There are 3 possible values that you can see in the console:
 
 ## Form inputs
 
-User consented to have his form inputs recorded.
+User consented to have their form inputs recorded.
 
 ```js
 <script>
@@ -52,7 +52,7 @@ User consented to have his form inputs recorded.
 
 ## IP address
 
-User consented to have his IP address recorded.
+User consented to have their IP address recorded.
 
 ```js
 <script>


### PR DESCRIPTION
I have some questions about this help page:

1. The image from the .md file is not visible at https://smartlook.github.io/docs/web/gdpr/ but is visible at https://help.smartlook.com/en/articles/3422023-gdpr-and-smartlook-options. What's the difference between the two pages? Are they published from this same source?

2. https://help.smartlook.com/en/articles/3422023-gdpr-and-smartlook-options refers to "Read more about GDPR in our HELP section.". That *is* the help section already, correct?

3. What exactly do these lines refer to,

```js
// in this variable inser your consent
  var consentText = 'Here goes consent text from your website.';
```

Is `consentText` a variable to hold the text that's used to *ask* the user for consent? Or to *thank* them for giving consent? Where will that text be displayed? What would be an example of "consent text"?

I *assume* it's up to the website to obtain consent however they want, then these variables (`const`s actually) should be called `consentConfirmation`? The whole consent flow is a bit unclear to me from that page :)