### PR TITLE
slSensitive IB inspectability documentation and cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .docz
 node_modules
 /docs
+src/.DS_Store
+.DS_Store

--- a/src/api_reference.mdx
+++ b/src/api_reference.mdx
@@ -1014,6 +1014,10 @@ self.someView.slSensitive = YES;
 }}
 />
 
+<TextBlock kind="note" visibleOn="ios">{`
+Note also, that there is a small workaround that makes  \`slSensitive\` property of \`UIView\` inspectable in Xcode Interface Builder, i.e., it is not necessary creating an \`@IBOutlet\` for a view that is designed in the Interface Builder just in order to set its sensitivity. See our <Link to="/docs/sdk/cookbooks/how-to-make-smartlook-properties-inspectable">How to make Smartlook properties inspectable</Link> cookbook.
+`}</TextBlock>
+
 <TextBlock visibleOn="android,ios,react,xamarin">{`
 If view no longer needs to be blacklisted:
 `}</TextBlock>
@@ -1266,6 +1270,10 @@ self.someView.slSensitive = NO;
     },
   }}
 />
+
+<TextBlock kind="note" visibleOn="ios">{`
+Note also, that there is a small workaround that makes  \`slSensitive\` property of \`UIView\` inspectable in Xcode Interface Builder, i.e., it is not necessary creating an \`@IBOutlet\` for a view that is designed in the Interface Builder just in order to set its sensitivity. See our <Link to="/docs/sdk/cookbooks/how-to-make-smartlook-properties-inspectable">How to make Smartlook properties inspectable</Link> cookbook.
+`}</TextBlock>
 
 <TextBlock visibleOn="android,ios,xamarin">{`
 \`View\` can be removed from whitelist by calling:

--- a/src/conceptual/handling-sensitive-data.mdx
+++ b/src/conceptual/handling-sensitive-data.mdx
@@ -189,7 +189,7 @@ Smartlook.Analytics.RegisterWhitelistedObject(SomeView);
 
 
 <TextBlock kind="note" visibleOn="ios">{`
-Note also, that the \`slSensitive\` property of \`UIView\` can be set in Xcode Interface Builder as well, i.e., it is not necessary creating an \`@IBOutlet\` for a view that is designed in the Interface Builder just in order to set its sensitivity.
+Note also, that there is a small workaround that makes  \`slSensitive\` property of \`UIView\` inspectable in Xcode Interface Builder, i.e., it is not necessary creating an \`@IBOutlet\` for a view that is designed in the Interface Builder just in order to set its sensitivity. See our <Link to="/docs/sdk/cookbooks/how-to-make-smartlook-properties-inspectable">How to make Smartlook properties inspectable</Link> cookbook.
 `}</TextBlock>
 
 <TextBlock>{`

--- a/src/cookbook/how-to-make-smartlook-properties-inspectable.mdx
+++ b/src/cookbook/how-to-make-smartlook-properties-inspectable.mdx
@@ -1,0 +1,35 @@
+---
+name: Making Smartlook UIView Properties Inspectable in Xcode
+menu: SDK Cookbooks
+route: /docs/sdk/cookbooks/how-to-make-smartlook-properties-inspectable
+showPlatformSelect: true
+---
+
+import { Title, TextBlock, Code } from 'components'
+
+<Title>Making Smartlook UIView Properties Inspectable in Xcode</Title>
+
+<TextBlock kind="important">{`
+This guide applies to all frameworks that use Xcode Interface Builder.
+`}</TextBlock>
+
+Inspectable properties of visual elements used in Xcode Design Builder enable quick code-less editing of their values. 
+
+Unfortunatelly, properties exported from an external framework like Smartlook cannot be directly attributed as `IBInspectable` to enable this functionality.
+
+There is, however, a neat straigthforward workaround to enable this functionality by wrapping the Smartlook properties in own inspectable properties via a custom `UIView` extension:
+
+<Code
+	snippets={{
+		swift: `
+extension UIView {
+    @IBInspectable var smartlookSensitive: Bool {
+        get { return slSensitive }
+        set { slSensitive = newValue }
+    }
+}`,
+	}}
+/>
+
+By adding this code to your app, a wrapper is created around Smartlook's `slSensitive` property that publishes its value to Interface Builder as `smartlookSensitive`. You can indeed use another name for the new inspectable property so it fits your code naming conventions.
+


### PR DESCRIPTION
Documentation update that addresses the issues with IBInspectability of properties that are imported from external frameworks like Smartlook.

See also: https://github.com/smartlook/smartlook-mobile-issue-tracker/issues/48

Please merge immediately when approving.