### PR TITLE
iOS Update related to bitcode compatibility

### DIFF
--- a/src/sdk-installation/changelogs.mdx
+++ b/src/sdk-installation/changelogs.mdx
@@ -12,6 +12,14 @@ import { usePlatforms } from 'hooks'
 
 This changelog shows all relevant releases for each platform.
 
+<TextBlock visibleOn="ios">{`
+## iOS [1.7.6.1] - 2021-05-10
+\n
+### Fixed
+- Build identical to the previous version released using Xcode 12.4 to keep bitcode compatibility
+(<Link to="https://github.com/smartlook/smartlook-mobile-issue-tracker/issues/83">the related github issue</Link>)\n
+***`}</TextBlock>
+
 <TextBlock kind="important" visibleOn="react,cordova,ionic,cocos,flutter">
 {`
 Standard iOS/Android SDK is linked as a Cocopoad/Gradle dependency to React Native, Cordova, Ionic and Cocos plugins. \n

--- a/src/sdk-installation/ios.mdx
+++ b/src/sdk-installation/ios.mdx
@@ -26,7 +26,7 @@ If you experience \"**Found an unexpected Mach-O header code: 0x72613c2**\" erro
 
 ### 2. Direct integration
 
-Smartlook can also be added directly to the app project by **downloading** our latest [Smartlook iOS SDK (1.7.6)](https://sdk.smartlook.com/ios/smartlook-ios-sdk-1.7.6.3318.zip), unzipping the file, and adding `Smartlook.xcframework` to the Xcode project.
+Smartlook can also be added directly to the app project by **downloading** our latest [Smartlook iOS SDK (1.7.6.1)](https://sdk.smartlook.com/ios/smartlook-ios-sdk-1.7.6.1.3345.zip), unzipping the file, and adding `Smartlook.xcframework` to the Xcode project.
 
 ### 3. Cocoapods 
 


### PR DESCRIPTION
In order to keep compatibility with older versions of XCode still used by some of our clients we had to release the SDK compiled by Xcode 12.4… 