### PR TITLE
iOS SDK Release 1.8.6

### DIFF
--- a/src/sdk-installation/changelogs.mdx
+++ b/src/sdk-installation/changelogs.mdx
@@ -13,7 +13,16 @@ import { usePlatforms } from 'hooks'
 This changelog shows all relevant releases for each platform.
 
 <TextBlock visibleOn="ios">{`
-## iOS [1.8.5] - 2022-00-08
+## iOS [1.8.6] - 2022-02-18
+\n
+Maintenance and bugfixing release.
+### Fixed
+- the issue with wrongly generated dSYM file that could break debugging in some setups
+***`}</TextBlock>
+
+
+<TextBlock visibleOn="ios">{`
+## iOS [1.8.5] - 2022-02-08
 \n
 Maintenance and bugfixing release.
 ### Added

--- a/src/sdk-installation/ios.mdx
+++ b/src/sdk-installation/ios.mdx
@@ -20,7 +20,7 @@ Add this Swift Package – `https://github.com/smartlook/SmartlookSwiftPackage`.
 
 ### 2. Direct integration
 
-Smartlook can also be added directly to the app project by **downloading** our latest [Smartlook iOS SDK (1.8.5)](https://sdk.smartlook.com/ios/smartlook-ios-sdk-1.8.5.57.zip), unzipping the file, and adding `Smartlook.xcframework` to the Xcode project.
+Smartlook can also be added directly to the app project by **downloading** our latest [Smartlook iOS SDK (1.8.6)](https://sdk.smartlook.com/ios/smartlook-ios-sdk-1.8.6.65.zip), unzipping the file, and adding `Smartlook.xcframework` to the Xcode project.
 
 ### 3. Cocoapods 
 


### PR DESCRIPTION
iOS Release 1.8.6

Fixes the issue with wrongly generated dSYM file that could break debugging in some setups